### PR TITLE
Added support for custom proxy urls

### DIFF
--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -27,6 +27,12 @@ class Vite
         if (is_file(public_path('/hot'))) {
             $url = rtrim(file_get_contents(public_path('/hot')));
 
+            $customUrl = app('config')->get('app.vite_hot_proxy_url');
+
+            if (! empty($customUrl)) {
+                $url = $customUrl;
+            }
+
             return new HtmlString(
                 $entrypoints
                     ->map(fn ($entrypoint) => $this->makeTag("{$url}/{$entrypoint}"))
@@ -90,6 +96,12 @@ class Vite
         }
 
         $url = rtrim(file_get_contents(public_path('/hot')));
+
+        $customUrl = app('config')->get('app.vite_hot_proxy_url');
+
+        if (! empty($customUrl)) {
+            $url = $customUrl;
+        }
 
         return new HtmlString(
             sprintf(


### PR DESCRIPTION
Added the support for the `app.vite_hot_proxy_url` config. This config will be used for the base url of the tag generated with the `@vite` directive

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
